### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,7 +2,7 @@
 CHANGES
 =======
 
-3.2 (unreleased)
+4.0 (unreleased)
 ----------------
 
 - Nothing changed yet.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ CHANGES
 4.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace. Caution: This change requires to switch all packages in the namespace of the package to versions using a PEP 420 namespace.
 
 
 3.1 (2025-04-02)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@
 
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -65,9 +64,6 @@ setup(
     ],
     url='https://github.com/zopefoundation/z3c.batching',
     license='ZPL-2.1',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['z3c'],
     python_requires='>=3.9',
     install_requires=[
         'setuptools',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def read(*rnames):
 
 setup(
     name='z3c.batching',
-    version='3.2.dev0',
+    version='4.0.dev0',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.dev',
     description='List batching support',

--- a/src/z3c/__init__.py
+++ b/src/z3c/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace. Caution: This change requires to switch all packages in the namespace of the package to versions using a PEP 420 namespace.**
- **Switch to PEP 420 native namespace.**
